### PR TITLE
Added schema registration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,9 +111,9 @@ package-dir = { "" = "src" }
 where = ["src"]
 
 [project.entry-points.'nomad.plugin']
-parser_entry_point = "nomad_parser_plugins_camels_files.parsers:camels_parser_entry_point"
-app_entry_point = "nomad_parser_plugins_camels_files.apps:camels_app"
-
+camels_schema_package = "nomad_parser_plugins_camels_files.parsers:camels_schema_package"
+camels_parser = "nomad_parser_plugins_camels_files.parsers:camels_parser"
+camels_app = "nomad_parser_plugins_camels_files.apps:camels_app"
 
 [tool.cruft]
 # Avoid updating workflow files, this leads to permissions issues

--- a/src/nomad_parser_plugins_camels_files/apps/__init__.py
+++ b/src/nomad_parser_plugins_camels_files/apps/__init__.py
@@ -3,67 +3,72 @@ from nomad.config.models.plugins import AppEntryPoint
 from nomad.config.models.ui import (
     App,
     Column,
-    Columns,
-    FilterMenu,
-    FilterMenus,
-    Filters,
+    Menu,
+    MenuItemHistogram,
+    MenuItemTerms,
+    SearchQuantities,
 )
-schema = 'nomad_parser_plugins_camels_files.parsers.parser.CamelsMeasurement' 
+
+schema = 'nomad_parser_plugins_camels_files.parsers.parser.CamelsMeasurement'
 
 camels_app = AppEntryPoint(
-    name="CAMELS App",
-    description="App that allows you to search and navigate your CAMELS measurements.",
+    name='CAMELS App',
+    description='App that allows you to search and navigate your CAMELS measurements.',
     app=App(
         label='CAMELS App',
         path='myapp',
         category='Experiment',
-        filters=Filters(
-            include=['*#nomad_parser_plugins_camels_files.parsers.parser.CamelsMeasurement'],
-        ),
+        search_quantities=SearchQuantities(include=['*#{schema}']),
         columns=[
             Column(quantity='entry_id', selected=True),
-            Column(
-                quantity=f'entry_name',
-                selected=True
-            ),
-            Column(
-                quantity=f'resjunktest',
-                selected=True
-            ),
-            Column(
-                quantity=f'data.data.camels_user#{schema}',
-                selected=True
-            ),
-            Column(quantity='upload_create_time')
+            Column(quantity='entry_name', selected=True),
+            Column(quantity='resjunktest', selected=True),
+            Column(quantity=f'data.camels_user#{schema}', selected=True),
+            Column(quantity='upload_create_time'),
         ],
-        filter_menus=FilterMenus(
-        options={
-            'custom_quantities': FilterMenu(label='User Defined Quantities'),
-            'author': FilterMenu(label='Author / Origin / Dataset'),
-        }
-        ),
-        filters_locked={
-            'section_defs.definition_qualified_name': [
-                'nomad_parser_plugins_camels_files.parsers.parser.CamelsMeasurement',
+        menu=Menu(
+            items=[
+                Menu(
+                    title='Camels',
+                    items=[
+                        MenuItemTerms(
+                            search_quantity=f'data.session_name#{schema}',
+                            options=5,
+                        ),
+                        MenuItemHistogram(
+                            x=f'data.end_time#{schema}',
+                        ),
+                    ],
+                ),
+                Menu(
+                    title='Author / Origin / Dataset',
+                    items=[
+                        MenuItemTerms(
+                            search_quantity='authors.name',
+                            options=0,
+                        ),
+                        MenuItemHistogram(
+                            x='upload_create_time',
+                        ),
+                        MenuItemTerms(
+                            search_quantity='external_db',
+                            options=5,
+                            show_input=False,
+                        ),
+                        MenuItemTerms(
+                            search_quantity='datasets.dataset_name',
+                        ),
+                        MenuItemTerms(
+                            search_quantity='datasets.doi',
+                            options=0,
+                        ),
+                    ],
+                ),
             ],
-        },
-
-),
+        ),
+        filters_locked={'section_defs.definition_qualified_name': schema},
+    ),
 )
-    
-
-
-
-    
-
-
-
-
-
-
-
-
-
 
 
 # ---------------------------------------------------------------------------------------------------

--- a/src/nomad_parser_plugins_camels_files/apps/__init__.py
+++ b/src/nomad_parser_plugins_camels_files/apps/__init__.py
@@ -1,4 +1,3 @@
-import yaml
 from nomad.config.models.plugins import AppEntryPoint
 from nomad.config.models.ui import (
     App,
@@ -18,13 +17,13 @@ camels_app = AppEntryPoint(
         label='CAMELS App',
         path='myapp',
         category='Experiment',
-        search_quantities=SearchQuantities(include=['*#{schema}']),
+        search_quantities=SearchQuantities(include=[f'*#{schema}']),
         columns=[
-            Column(quantity='entry_id', selected=True),
-            Column(quantity='entry_name', selected=True),
-            Column(quantity='resjunktest', selected=True),
-            Column(quantity=f'data.camels_user#{schema}', selected=True),
-            Column(quantity='upload_create_time'),
+            Column(search_quantity='entry_id', selected=True),
+            Column(search_quantity='entry_name', selected=True),
+            Column(search_quantity='resjunktest', selected=True),
+            Column(search_quantity=f'data.camels_user#{schema}', selected=True),
+            Column(search_quantity='upload_create_time'),
         ],
         menu=Menu(
             items=[

--- a/src/nomad_parser_plugins_camels_files/parsers/__init__.py
+++ b/src/nomad_parser_plugins_camels_files/parsers/__init__.py
@@ -1,19 +1,29 @@
-from nomad.config.models.plugins import ParserEntryPoint
-from pydantic import Field
+from nomad.config.models.plugins import ParserEntryPoint, SchemaPackageEntryPoint
 
 
 class CamelsParserEntryPoint(ParserEntryPoint):
-    parameter: int = Field(0, description='Custom configuration parameter')
-
     def load(self):
         from nomad_parser_plugins_camels_files.parsers.parser import CamelsParser
 
         return CamelsParser(**self.dict())
 
 
-camels_parser_entry_point = CamelsParserEntryPoint(
+camels_parser = CamelsParserEntryPoint(
     name='CamelsParser',
     description='New parser entry point configuration.',
     mainfile_name_re=r'^.*\.(h5|hdf5|nxs)$',
     mainfile_mime_re='(application/x-hdf)',
+)
+
+
+class CamelsSchemaPackageEntryPoint(SchemaPackageEntryPoint):
+    def load(self):
+        from nomad_parser_plugins_camels_files.parsers.parser import m_package
+
+        return m_package
+
+
+camels_schema_package = CamelsSchemaPackageEntryPoint(
+    name='CamelsSchemaPackage',
+    description='Contains the data model for recording NOMAD Camels entries.',
 )

--- a/src/nomad_parser_plugins_camels_files/parsers/parser.py
+++ b/src/nomad_parser_plugins_camels_files/parsers/parser.py
@@ -15,7 +15,7 @@ from datetime import datetime
 import h5py
 import numpy as np
 from nomad.config import config
-from nomad.datamodel import EntryData
+from nomad.datamodel import Schema
 from nomad.datamodel.datamodel import EntryMetadata
 from nomad.datamodel.metainfo.annotations import (
     ELNAnnotation,
@@ -35,7 +35,7 @@ from .utils import create_archive
 m_package = SchemaPackage()
 
 
-class CamelsMeasurement(Measurement, EntryData):
+class CamelsMeasurement(Measurement, Schema):
     m_def = Section(
         a_eln=ELNAnnotation(
             properties=SectionProperties(
@@ -86,7 +86,6 @@ class CamelsMeasurement(Measurement, EntryData):
             label='Session name',
         ),
     )
-
     camels_user = Quantity(
         type=str,
         description='CAMELS User',
@@ -95,7 +94,6 @@ class CamelsMeasurement(Measurement, EntryData):
             label='CAMELS User',
         ),
     )
-
     camels_file = Quantity(
         type=str,
         description='CAMELS file reference',


### PR DESCRIPTION
With this change, you should now be able to use the Camels definitions in your app. The main change is that the schema is now registered correctly in `src/parsers/__init__.py`.

I would, however, strongly suggest moving the schema definition to the `schema_packages` folder. If you don't yet have generated a lot of such Camels data, this should be fairly easy: you would just need to reprocess the existing data.

The PR also includes a lot of small changes that were automatically done just by running the `ruff` linter. I also hoisted a lot of the Python imports to the top of the file. I updated your app to use the latest features (see especially the `menu` attribute where you can customize the menu shown on the left side of the search interface).